### PR TITLE
src: inline spki asn1 definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/Brightspace/node-jwk-to-pem#readme",
   "dependencies": {
     "asn1.js": "^4.0.0",
-    "asn1.js-rfc3280": "^4.0.0",
     "elliptic": "^6.0.1"
   },
   "devDependencies": {

--- a/src/ec.js
+++ b/src/ec.js
@@ -1,8 +1,7 @@
 'use strict';
 
 var asn1 = require('asn1.js'),
-	EC = require('elliptic').ec,
-	rfc3280 = require('asn1.js-rfc3280');
+	EC = require('elliptic').ec;
 
 var b64ToBn = require('./b64-to-bn');
 
@@ -102,7 +101,7 @@ function keyToPem(crv, key, opts) {
 
 		privateKey.fill(0);
 	} else {
-		result = rfc3280.SubjectPublicKeyInfo.encode({
+		result = SubjectPublicKeyInfo.encode({
 			algorithm: {
 				algorithm: [1, 2, 840, 10045, 2, 1],
 				parameters: parameters
@@ -136,6 +135,20 @@ var ECPrivateKey = asn1.define('ECPrivateKey', /* @this */ function() {
 		this.key('privateKey').octstr(),
 		this.key('parameters').explicit(0).optional().any(),
 		this.key('publicKey').explicit(1).optional().bitstr()
+	);
+});
+
+var AlgorithmIdentifier = asn1.define('AlgorithmIdentifier', /* @this */ function() {
+	this.seq().obj(
+		this.key('algorithm').objid(),
+		this.key('parameters').optional().any()
+	);
+});
+
+var SubjectPublicKeyInfo = asn1.define('SubjectPublicKeyInfo', /* @this */ function() {
+	this.seq().obj(
+		this.key('algorithm').use(AlgorithmIdentifier),
+		this.key('subjectPublicKey').bitstr()
 	);
 });
 


### PR DESCRIPTION
asn1.js-rfc3280 has been replaced by asn1.js-rfc5280, which is larger still
we only need the spki bits out of it, so it didn't seem particularly worthwhile
particularly for native-crypto's usecase. this will be a smaller bundle for them