### PR TITLE
upgraded asn1.js for buffer deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/Brightspace/node-jwk-to-pem#readme",
   "dependencies": {
-    "asn1.js": "^4.5.2",
+    "asn1.js": "5.3.0",
     "elliptic": "^6.5.2",
     "safe-buffer": "^5.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/Brightspace/node-jwk-to-pem#readme",
   "dependencies": {
-    "asn1.js": "5.3.0",
+    "asn1.js": "^5.3.0",
     "elliptic": "^6.5.2",
     "safe-buffer": "^5.0.1"
   },


### PR DESCRIPTION
> DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

This error has been fixed with asn1.js v 5.3.0