### PR TITLE
Fix dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
+    directory: /
+    schedule: daily


### PR DESCRIPTION
I accidentally committed this directly to master which skipped CI.
I turned on "Include Administrators" on the branch protection rule.