### PR TITLE
feat: build script to build a bundle ready to use in browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ package-lock.json
 *.swp
 
 .nyc_output
+
+build

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ var jwk = { kty: 'EC', crv: 'P-256', x: '...', y: '...' },
 jwt.verify(token, pem);
 ```
 
+## Build bundle for browser (or Postman)
+If you find yourself in the need to have this amazing function in your brower-side code or, why not, in Postman, you can build a bundle by means of:
+```sh
+npm run build
+```
+which will produce a nice `build/bundle.js` ready to use.
+
 ### Support
 
 key type | support level

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "check-style": "eslint .",
     "pretest": "npm run check-style",
     "test": "nyc --all --include src -- mocha spec",
-    "report-cov": "nyc report --reporter=text-lcov | coveralls"
+    "report-cov": "nyc report --reporter=text-lcov | coveralls",
+    "build": "browserify -p tinyify src/jwk-to-pem.js > ./build/bundle.js -s jwk2pem"
   },
   "repository": {
     "type": "git",
@@ -36,12 +37,14 @@
     "safe-buffer": "^5.0.1"
   },
   "devDependencies": {
+    "browserify": "^16.5.1",
     "chai": "^4.2.0",
     "coveralls": "^3.0.5",
     "eslint": "^6.0.1",
     "eslint-config-brightspace": "^0.6.4",
     "jwa": "^1.1.4",
     "mocha": "^6.2.0",
-    "nyc": "^14.1.1"
+    "nyc": "^14.1.1",
+    "tinyify": "^2.5.2"
   }
 }


### PR DESCRIPTION
- [x] update docs
- [x] update .gitignore 

I found myself in the need to use such an amazing function inside my Postman tests. By taking inspiration from [this](https://joolfe.github.io/postman-util-lib/#postman-collection) awesome plugin for Postman, I managed to create a bundle which I can use in Postman to convert `JWK` into `PEM`. 
