### PR TITLE
remove registry-url from Brightspace/setup-node

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,10 +41,9 @@ jobs:
       - uses: Brightspace/setup-node@main
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'
 
       - run: npm install
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    
+

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "url": "https://github.com/Brightspace/node-jwk-to-pem/issues"
   },
   "homepage": "https://github.com/Brightspace/node-jwk-to-pem#readme",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "dependencies": {
     "asn1.js": "^5.3.0",
     "elliptic": "^6.6.1",


### PR DESCRIPTION
The `registry-url` input will soon be managed by Brightspace/setup-node itself.
The registry to publish packages to is now defined in `publishConfig` in `package.json`.

[HOD-4561 - Proxy Registry > Update Brightspace/setup-node](https://desire2learn.atlassian.net/browse/HOD-4561)